### PR TITLE
Fix PyMusicLooper "invalid value" "not a valid float" on non-US cultures

### DIFF
--- a/MSUScripter/Services/PyMusicLooperService.cs
+++ b/MSUScripter/Services/PyMusicLooperService.cs
@@ -147,14 +147,14 @@ public class PyMusicLooperService
         var match = regex.Match(result);
         if (match.Success)
         {
-            loopStart = int.Parse(match.Groups[0].Value.Split(" ")[1]);
+            loopStart = int.Parse(match.Groups[0].Value.Split(" ")[1], CultureInfo.InvariantCulture);
         }
 
         regex = new Regex(@"LOOP_END: (\d)+");
         match = regex.Match(result);
         if (match.Success)
         {
-            loopEnd = int.Parse(match.Groups[0].Value.Split(" ")[1]);
+            loopEnd = int.Parse(match.Groups[0].Value.Split(" ")[1], CultureInfo.InvariantCulture);
         }
 
         if (loopStart == -1 || loopEnd == -1)

--- a/MSUScripter/Services/PyMusicLooperService.cs
+++ b/MSUScripter/Services/PyMusicLooperService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -187,27 +188,27 @@ public class PyMusicLooperService
 
         return result.Split("\n")
             .Select(x => x.Split(" "))
-            .Select(x => (int.Parse(x[0]), int.Parse(x[1]), decimal.Parse(x[4])))
+            .Select(x => (int.Parse(x[0], CultureInfo.InvariantCulture), int.Parse(x[1], CultureInfo.InvariantCulture), decimal.Parse(x[4], CultureInfo.InvariantCulture)))
             .ToList();
     }
 
     private string GetArguments(string filePath, double minDurationMultiplier = 0.25, int? minLoopDuration = null, int? maxLoopDuration = null, int? approximateLoopStart = null, int? approximateLoopEnd = null)
     {
-        var arguments = $"export-points --min-duration-multiplier {minDurationMultiplier} --path \"{filePath}\"";
+        var arguments = string.Create(CultureInfo.InvariantCulture, $"export-points --min-duration-multiplier {minDurationMultiplier} --path \"{filePath}\"");
         
         if (minLoopDuration != null)
         {
-            arguments += $" --min-loop-duration {minLoopDuration}";
+            arguments += string.Create(CultureInfo.InvariantCulture, $" --min-loop-duration {minLoopDuration}");
         }
 
         if (maxLoopDuration != null)
         {
-            arguments += $" --max-loop-duration {maxLoopDuration}";
+            arguments += string.Create(CultureInfo.InvariantCulture, $" --max-loop-duration {maxLoopDuration}");
         }
 
         if (approximateLoopStart != null && approximateLoopEnd != null)
         {
-            arguments += $" --approx-loop-position {approximateLoopStart} {approximateLoopEnd}";
+            arguments += string.Create(CultureInfo.InvariantCulture, $" --approx-loop-position {approximateLoopStart} {approximateLoopEnd}");
         }
 
         return arguments;
@@ -258,7 +259,8 @@ public class PyMusicLooperService
         using var stream = File.OpenRead(path);
         var pathHash = GetHexString(md5.ComputeHash(Encoding.Default.GetBytes(path)));
         var fileHash = GetHexString(md5.ComputeHash(stream));
-        return Path.Combine(_cachePath, $"{pathHash}_{fileHash}_{_currentVersion}_{Math.Round(minDurationMultiplier, 2)}_{minLoopDuration}_{maxLoopDuration}_{approximateLoopStart}_{approximateLoopEnd}.yml");
+        var fileName = string.Create(CultureInfo.InvariantCulture, $"{pathHash}_{fileHash}_{_currentVersion}_{Math.Round(minDurationMultiplier, 2)}_{minLoopDuration}_{maxLoopDuration}_{approximateLoopStart}_{approximateLoopEnd}.yml");
+        return Path.Combine(_cachePath, fileName);
     }
 
     private string GetHexString(byte[] bytes)


### PR DESCRIPTION
I updated PyMusicLooperService to explicitly use InvariantCulture when formatting and parsing ints and doubles. Ints probably weren't necessary, but I added those too just in case. 

Doubles, however, would fail completely on my machine since I have my regional formatting settings set to _English (Netherlands)_, which would use e.g. `0,25` instead of `0.25`, which PyMusicLooper would complain about.

Likewise, double.Parse (for the confidence) would return e.g. 98xxx values instead of 0.98xxx.

Fixes #53 