### PR TITLE
Release 2.1.0

### DIFF
--- a/.idea/.idea.MSUScripter/.idea/avalonia.xml
+++ b/.idea/.idea.MSUScripter/.idea/avalonia.xml
@@ -16,6 +16,7 @@
         <entry key="MSUScripter/Controls/MainWindow.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/MessageWindow.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/MsuBasicInfoPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
+        <entry key="MSUScripter/Controls/MsuOverviewPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/MsuPcmGenerationWindow.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/MsuSongInfoPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/MsuSongMsuPcmInfoPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
@@ -24,6 +25,7 @@
         <entry key="MSUScripter/Controls/NewProjectPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/PyMusicLooperPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/SettingsWindow.axaml" value="MSUScripter/MSUScripter.csproj" />
+        <entry key="MSUScripter/Controls/TrackOverviewPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/VideoCreatorWindow.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Themes/Light.axaml" value="MSUScripter/MSUScripter.csproj" />
       </map>

--- a/.idea/.idea.MSUScripter/.idea/avalonia.xml
+++ b/.idea/.idea.MSUScripter/.idea/avalonia.xml
@@ -23,6 +23,7 @@
         <entry key="MSUScripter/Controls/MsuTrackInfoPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/MusicLooperWindow.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/NewProjectPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
+        <entry key="MSUScripter/Controls/PackageMsuWindow.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/PyMusicLooperPanel.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/SettingsWindow.axaml" value="MSUScripter/MSUScripter.csproj" />
         <entry key="MSUScripter/Controls/TrackOverviewPanel.axaml" value="MSUScripter/MSUScripter.csproj" />

--- a/MSUScripter/Configs/MsuSongInfo.cs
+++ b/MSUScripter/Configs/MsuSongInfo.cs
@@ -12,6 +12,7 @@ public class MsuSongInfo
     public string? Url { get; set; }
     public string OutputPath { get; set; } = "";
     public bool IsAlt { get; set; }
+    public bool IsComplete { get; set; }
     public bool CheckCopyright { get; set; } = true;
     public DateTime LastModifiedDate { get; set; }
     public DateTime LastGeneratedDate { get; set; }

--- a/MSUScripter/Controls/AddSongWindow.axaml
+++ b/MSUScripter/Controls/AddSongWindow.axaml
@@ -12,7 +12,8 @@
         Loaded="Control_OnLoaded"
         Closing="Window_OnClosing"
         Icon="/Assets/MSUScripterIcon.ico"
-        x:DataType="viewModels:AddSongWindowViewModel">
+        x:DataType="viewModels:AddSongWindowViewModel"
+        DragDrop.AllowDrop="True">
     <DockPanel>
         
         <Grid ColumnDefinitions="*,*,*" DockPanel.Dock="Bottom" Margin="5">
@@ -67,6 +68,7 @@
                                           Filter="All Files:*"
                                           Margin="3 0 0 0"
                                           FilePath="{Binding FilePath, Mode=TwoWay}" 
+                                          IsEnabled="{Binding !RunningPyMusicLooper}"
                                           OnUpdated="FileControl_OnOnUpdated"
                     ></controls:FileControl>
                     

--- a/MSUScripter/Controls/AddSongWindow.axaml.cs
+++ b/MSUScripter/Controls/AddSongWindow.axaml.cs
@@ -71,7 +71,7 @@ public partial class AddSongWindow : Window
 
     private MsuProject _project = new();
 
-    private async void DropFile(object? sender, DragEventArgs e)
+    private void DropFile(object? sender, DragEventArgs e)
     {
         if (Model.RunningPyMusicLooper)
         {

--- a/MSUScripter/Controls/EditProjectPanel.axaml
+++ b/MSUScripter/Controls/EditProjectPanel.axaml
@@ -8,9 +8,9 @@
              x:Class="MSUScripter.Controls.EditProjectPanel"
              Unloaded="Control_OnUnloaded"
              x:DataType="viewModels:MsuProjectViewModel">
-    <DockPanel>
+    <Grid RowDefinitions="Auto,*,Auto">
         
-        <Grid DockPanel.Dock="Top" Margin="5" ColumnDefinitions="Auto,*,Auto">
+        <Grid Grid.Row="0" DockPanel.Dock="Top" Margin="5" ColumnDefinitions="Auto,*,Auto">
             <Button 
                 Name="PrevButton"
                 Grid.Column="0" 
@@ -61,7 +61,7 @@
             </Button>
         </Grid>
         
-        <Border DockPanel.Dock="Bottom">
+        <Border Grid.Row="2" DockPanel.Dock="Bottom">
             <Grid ColumnDefinitions="*,*,*">
                 <StackPanel Grid.Column="0" Name="AudioStackPanel" VerticalAlignment="Center" Margin="5 0 0 5"></StackPanel>
                 <TextBlock Grid.Column="1" Name="StatusMessage" HorizontalAlignment="Center" VerticalAlignment="Center"></TextBlock>
@@ -101,12 +101,14 @@
             
         </Border>
         
-        <Border BorderBrush="DimGray" BorderThickness="1" Margin="5">
-            <ScrollViewer>
+        <DockPanel Grid.Row="1" Name="PageDockPanel" IsVisible="False" Margin="5"></DockPanel>
+        
+        <Border Grid.Row="1" BorderBrush="DimGray" BorderThickness="1" Margin="5" Name="ScrollViewerBorder">
+            <ScrollViewer x:Name="ScrollViewer">
                 <StackPanel Orientation="Vertical" Name="PagePanel" Margin="10 10 10 10">
                 </StackPanel>
             </ScrollViewer>
         </Border>
         
-    </DockPanel>
+    </Grid>
 </UserControl>

--- a/MSUScripter/Controls/EditProjectPanel.axaml
+++ b/MSUScripter/Controls/EditProjectPanel.axaml
@@ -93,6 +93,7 @@
                                 <MenuItem Name="ExportButton_Msu" Header="Export _MSU" Click="ExportButton_Msu_OnClick"></MenuItem>
                                 <MenuItem Name="OpenFolderMenuItem" Header="Open _Folder" Click="OpenFolderMenuItem_OnClick"></MenuItem>
                                 <MenuItem Name="ExportButton_Video" Header="_Create Copyright Test Video" Click="ExportButton_Video_OnClick"></MenuItem>
+                                <MenuItem Name="ExportButton_Package" Header="_Package MSU Files into ZIP" Click="ExportButton_Package_OnClick"></MenuItem>
                             </MenuFlyout>
                         </SplitButton.Flyout>
                     </SplitButton>

--- a/MSUScripter/Controls/EditProjectPanel.axaml.cs
+++ b/MSUScripter/Controls/EditProjectPanel.axaml.cs
@@ -311,6 +311,7 @@ public partial class EditProjectPanel : UserControl
         var song = new MsuSongInfo();
         _converterService!.ConvertViewModel(songModel, song);
         _converterService!.ConvertViewModel(songModel.MsuPcmInfo, song.MsuPcmInfo);
+        var tempProject = _converterService!.ConvertProject(_projectViewModel!);
 
         if (asPrimary)
         {
@@ -319,7 +320,7 @@ public partial class EditProjectPanel : UserControl
             song.OutputPath = path;
         }
         
-        if (!_msuPcmService.CreatePcm(_project, song, out var message, out var generated, false))
+        if (!_msuPcmService.CreatePcm(tempProject, song, out var message, out var generated, false))
         {
             if (generated)
             {
@@ -358,7 +359,7 @@ public partial class EditProjectPanel : UserControl
         
         songModel.LastGeneratedDate = DateTime.Now;
 
-        var hasAlts = _project.Tracks.First(x => x.TrackNumber == songModel.TrackNumber).Songs.Count > 1;
+        var hasAlts = tempProject.Tracks.First(x => x.TrackNumber == songModel.TrackNumber).Songs.Count > 1;
         
         UpdateStatusBarText(hasAlts ? "PCM Generated - YAML Regeneration Needed" : "PCM Generated");
         return true;

--- a/MSUScripter/Controls/EditProjectPanel.axaml.cs
+++ b/MSUScripter/Controls/EditProjectPanel.axaml.cs
@@ -784,4 +784,11 @@ public partial class EditProjectPanel : UserControl
             DisplayPage(_projectViewModel.Tracks.OrderBy(x => x.TrackNumber).ToList().IndexOf(track) + 2);    
         }
     }
+
+    private void ExportButton_Package_OnClick(object? sender, RoutedEventArgs e)
+    {
+        this.Find<ComboBox>(nameof(PageComboBox))!.Focus();
+        var packageWindow = new PackageMsuWindow(_projectViewModel!);
+        packageWindow.ShowDialog(App.MainWindow!);
+    }
 }

--- a/MSUScripter/Controls/FileControl.axaml
+++ b/MSUScripter/Controls/FileControl.axaml
@@ -5,12 +5,13 @@
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="40"
              x:Class="MSUScripter.Controls.FileControl"
-             x:Name="MyFileControl">
+             x:Name="MyFileControl"
+             DragDrop.AllowDrop="True">
     <Grid ColumnDefinitions="*,Auto,Auto">
         <TextBox Grid.Column="0" 
                  Text="{Binding ElementName=MyFileControl, Path=FilePath}"
                  IsReadOnly="True" 
-                 IsEnabled="False" 
+                 IsEnabled="True"
                  Watermark="{Binding ElementName=MyFileControl, Path=Watermark}"
         />
         

--- a/MSUScripter/Controls/FileControl.axaml.cs
+++ b/MSUScripter/Controls/FileControl.axaml.cs
@@ -128,7 +128,7 @@ public partial class FileControl : UserControl
 
     private static IStorageFolder? PreviousFolder;
     
-    private async void DropFile(object? sender, DragEventArgs e)
+    private void DropFile(object? sender, DragEventArgs e)
     {
         var file = e.Data?.GetFiles()?.FirstOrDefault();
         if (file == null)
@@ -283,7 +283,7 @@ public partial class FileControl : UserControl
             var regex = $"({string.Join("|", regexParts)})";
             return Regex.IsMatch(file, regex);
         }
-        catch (Exception e)
+        catch
         {
             // Just ignore it
         }

--- a/MSUScripter/Controls/MsuSongInfoPanel.axaml
+++ b/MSUScripter/Controls/MsuSongInfoPanel.axaml
@@ -13,15 +13,21 @@
     <StackPanel Orientation="Vertical" Grid.IsSharedSizeScope="True">
         <controls:CardControl Margin="0 0 0 5" Name="MainGroupBox" HeaderText="Basic Details" DisplayHeaderButtons="True" Padding="10" HorizontalAlignment="Stretch">
             <controls:CardControl.HeaderButtons>
-                <Button 
-                    Name="RemoveButton"
-                    Grid.Column="1" 
-                    Padding="5 0"
-                    Margin="0 0 0 0"
-                    Click="RemoveButton_OnClick"
-                >
-                    <avalonia:MaterialIcon Kind="Delete"></avalonia:MaterialIcon>
-                </Button>
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Content="Song Finished" 
+                              Margin="0 0 15 0"
+                              IsChecked="{Binding IsComplete}"
+                    ></CheckBox>
+                    <Button 
+                        Name="RemoveButton"
+                        Grid.Column="1" 
+                        Padding="5 0"
+                        Margin="0 0 0 0"
+                        Click="RemoveButton_OnClick"
+                    >
+                        <avalonia:MaterialIcon Kind="Delete"></avalonia:MaterialIcon>
+                    </Button>
+                </StackPanel>
             </controls:CardControl.HeaderButtons>
             <StackPanel Orientation="Vertical">
                 <controls:LabeledControl Text="Song Name:" Hint="The name of the song" DisplayHint="True">

--- a/MSUScripter/Controls/MsuSongMsuPcmInfoPanel.axaml
+++ b/MSUScripter/Controls/MsuSongMsuPcmInfoPanel.axaml
@@ -26,7 +26,7 @@
             <StackPanel Orientation="Vertical">
                 
                 <controls:LabeledControl Text="Input File:" Hint="The file to be used as the input for this track/sub-track/sub-channel" DisplayHint="True">
-                    <controls:FileControl Name="FileControl" FilePath="{Binding File, Mode=TwoWay}" OnUpdated="FileControl_OnOnUpdated" Filter="All Files:*"></controls:FileControl>
+                    <controls:FileControl Name="FileControl" FilePath="{Binding File, Mode=TwoWay}" OnUpdated="FileControl_OnOnUpdated"></controls:FileControl>
                 </controls:LabeledControl>
                 
                 <controls:LabeledControl Text="Normalization:" Hint="Normalize the current track to the specified RMS level, overrides the global normalization value" DisplayHint="True">

--- a/MSUScripter/Controls/PackageMsuWindow.axaml
+++ b/MSUScripter/Controls/PackageMsuWindow.axaml
@@ -1,0 +1,25 @@
+﻿<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:viewModels="clr-namespace:MSUScripter.ViewModels"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        Width="800"
+        Height="600"
+        x:Class="MSUScripter.Controls.PackageMsuWindow"
+        Title="Package MSU"
+        Icon="/Assets/MSUScripterIcon.ico"
+        Loaded="Control_OnLoaded"
+        Closing="Window_OnClosing"
+        x:DataType="viewModels:PackageMsuViewModel">
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Bottom" HorizontalAlignment="Center" Margin="5">
+            <Button Name="CloseButton"
+                    Click="CloseButton_OnClick"
+                    Content="{Binding ButtonText}"></Button>
+        </StackPanel>
+        
+        <TextBox IsReadOnly="True" Text="{Binding Response}">
+        </TextBox>
+    </DockPanel>
+</Window>

--- a/MSUScripter/Controls/PackageMsuWindow.axaml.cs
+++ b/MSUScripter/Controls/PackageMsuWindow.axaml.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using MSUScripter.ViewModels;
+using Path = System.IO.Path;
+
+namespace MSUScripter.Controls;
+
+public partial class PackageMsuWindow : Window
+{
+    private readonly HashSet<string> _extensions = new()
+    {
+        ".txt",
+        ".pcm",
+        ".msu",
+        ".bat",
+        ".yml"
+    };
+
+    private bool _isRunning = false;
+    
+    private readonly CancellationTokenSource _cts = new();
+    
+    public PackageMsuWindow()
+    {
+        InitializeComponent();
+        DataContext = Model = new PackageMsuViewModel();
+    }
+
+    public PackageMsuWindow(MsuProjectViewModel project)
+    {
+        DataContext = Model = new PackageMsuViewModel()
+        {
+            Project = project
+        };
+        InitializeComponent();
+    }
+
+    private async Task PackageTask()
+    {
+        var msuFileInfo = new FileInfo(Model.Project.MsuPath);
+        var msuDirectory = msuFileInfo.DirectoryName!;
+        
+        var zipPath = await GetZipPath(msuDirectory);
+
+        if (string.IsNullOrEmpty(zipPath))
+        {
+            Close();
+            return;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Creating zip file {zipPath}");
+        Model.Response = sb.ToString();
+
+        try
+        {
+            if (File.Exists(zipPath))
+            {
+                File.Delete(zipPath);
+            }
+            
+            using var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create);
+            
+            foreach (var file in Directory.EnumerateFiles(msuDirectory, "*.*"))
+            {
+                if (_cts.Token.IsCancellationRequested)
+                {
+                    break;
+                }
+                
+                if (!_extensions.Contains(Path.GetExtension(file)))
+                {
+                    continue;
+                }
+                
+                sb.AppendLine($"... adding {file}");
+                Model.Response = sb.ToString();
+
+                try
+                {
+                    zip.CreateEntryFromFile(file, Path.GetFileName(file));
+                }
+                catch (Exception e2)
+                {
+                    sb.AppendLine($"Could not add {file} to zip file: {e2.Message}");
+                    Model.Response = sb.ToString();
+                    Model.ButtonText = "Close";
+                    return;
+                }
+            }
+            
+        }
+        catch (Exception e)
+        {
+            sb.AppendLine($"Could not create zip file: {e.Message}");
+            Model.Response = sb.ToString();
+            Model.ButtonText = "Close";
+            return;
+        }
+
+        if (_cts.Token.IsCancellationRequested)
+        {
+            try
+            {
+                if (File.Exists(zipPath))
+                {
+                    File.Delete(zipPath);
+                }
+            }
+            catch
+            {
+                // Do nothing
+            }
+        }
+        else
+        {
+            _isRunning = false;
+            sb.AppendLine("Complete!");
+            Model.Response = sb.ToString();
+            Model.ButtonText = "Close";
+        }
+    }
+
+    private async Task<string?> GetZipPath(string msuDirectory)
+    {
+        var path = await StorageProvider.TryGetFolderFromPathAsync(msuDirectory);
+        
+        var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Select Desired MSU Zip File",
+            FileTypeChoices = new List<FilePickerFileType>()
+            {
+                new("zip file") { Patterns = new List<string>() { "*.zip" } }
+            },
+            ShowOverwritePrompt = true,
+            SuggestedStartLocation = path,
+        });
+
+        return file?.Path.LocalPath;
+    }
+
+    protected PackageMsuViewModel Model { get; set; }
+
+    private void CloseButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private void Control_OnLoaded(object? sender, RoutedEventArgs e)
+    {
+        _isRunning = true;
+        Task.Run(PackageTask);
+    }
+
+    private void Window_OnClosing(object? sender, WindowClosingEventArgs e)
+    {
+        if (_isRunning)
+        {
+            _cts.Cancel();
+        }
+    }
+}

--- a/MSUScripter/Controls/PyMusicLooperPanel.axaml.cs
+++ b/MSUScripter/Controls/PyMusicLooperPanel.axaml.cs
@@ -69,6 +69,7 @@ public partial class PyMusicLooperPanel : UserControl
         {
             _model.Message = message;
             _model.DisplayGitHubLink = true;
+            OnUpdated?.Invoke(this, EventArgs.Empty);
             return;
         }
 
@@ -110,6 +111,7 @@ public partial class PyMusicLooperPanel : UserControl
                 return;
             }
 
+            OnUpdated?.Invoke(this, EventArgs.Empty);
             _model.Message = message;
         });
     }

--- a/MSUScripter/Controls/PyMusicLooperPanel.axaml.cs
+++ b/MSUScripter/Controls/PyMusicLooperPanel.axaml.cs
@@ -88,6 +88,13 @@ public partial class PyMusicLooperPanel : UserControl
             return;
         }
 
+        if (_model.ApproximateStart >= 0 != _model.ApproximateEnd >= 0)
+        {
+            _model.Message = "Both approximate loop start and end times must be filled out";
+            OnUpdated?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
         Task.Run(() =>
         {
             _model.Message = "Running PyMusicLooper";

--- a/MSUScripter/Controls/SettingsWindow.axaml
+++ b/MSUScripter/Controls/SettingsWindow.axaml
@@ -37,7 +37,6 @@
                         Grid.Column="0"
                         FilePath="{Binding MsuPcmPath, Mode=TwoWay}"
                         FileInputType="OpenFile"
-                        Filter="All Files:*"
                     ></controls:FileControl>
                     <Button Grid.Column="1"
                             Name="ValidateMsuPcmButton"

--- a/MSUScripter/Controls/TrackOverviewPanel.axaml
+++ b/MSUScripter/Controls/TrackOverviewPanel.axaml
@@ -1,0 +1,47 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:MSUScripter.ViewModels"
+             xmlns:controls="clr-namespace:MSUScripter.Controls"
+             xmlns:tools1="clr-namespace:MSUScripter.Tools"
+             xmlns:configs="clr-namespace:MSUScripter.Configs"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="MSUScripter.Controls.TrackOverviewPanel"
+             x:DataType="viewModels:TrackOverviewViewModel">
+    <DockPanel>
+        
+        <Grid DockPanel.Dock="Bottom" ColumnDefinitions="*,Auto" RowDefinitions="Auto, Auto">
+            <TextBlock Grid.Row="0" Grid.Column="0" Margin="10" Text="{Binding CompletedSongDetails}"></TextBlock>
+            <TextBlock Grid.Row="0" Grid.Column="1" Margin="10" Text="{Binding CompletedTrackDetails}"></TextBlock>
+            <Separator Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Margin="0 0"></Separator>
+        </Grid>
+        <DataGrid Name="TrackDataGrid" 
+                  ItemsSource="{Binding Rows}" 
+                  AutoGenerateColumns="False" 
+                  CanUserReorderColumns="False" 
+                  CanUserResizeColumns="False"
+                  IsReadOnly="True"
+                  RowBackground="{DynamicResource CardBackground}"
+                  SelectionMode="Single"
+                  SelectedIndex="{Binding SelectedIndex}"
+                  DoubleTapped="AudioDataGrid_OnDoubleTapped"
+        >
+            <DataGrid.Columns>
+                <DataGridTemplateColumn Header="Finished" SortMemberPath="SongInfo.IsComplete">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <CheckBox Name="IsCompleteCheckBox" IsVisible="{Binding HasSong}" IsChecked="{Binding SongInfo.IsComplete}" IsCheckedChanged="IsCompleteCheckBox_OnIsCheckedChanged"></CheckBox>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="Track"  Binding="{Binding TrackNumber}"/>
+                <DataGridTextColumn Header="Track Name"  Binding="{Binding TrackName}"/>
+                <DataGridTextColumn Header="Song Name"  Binding="{Binding Name}"/>
+                <DataGridTextColumn Header="Artist Name"  Binding="{Binding Artist}"/>
+                <DataGridTextColumn Header="Album Name"  Binding="{Binding Album}"/>
+                <DataGridTextColumn Header="File(s)"  Binding="{Binding File}"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</UserControl>

--- a/MSUScripter/Controls/TrackOverviewPanel.axaml.cs
+++ b/MSUScripter/Controls/TrackOverviewPanel.axaml.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using MSUScripter.Models;
+using MSUScripter.ViewModels;
+
+namespace MSUScripter.Controls;
+
+public partial class TrackOverviewPanel : UserControl
+{
+
+    public TrackOverviewPanel()
+    {
+        InitializeComponent();
+    }
+    
+    public TrackOverviewPanel(List<MsuTrackInfoViewModel> tracks)
+    {
+        InitializeComponent();
+        
+        foreach (var track in tracks.OrderBy(x => x.TrackNumber))
+        {
+            if (!track.Songs.Any())
+            {
+                Model.Rows.Add(new TrackOverviewViewModel.TrackOverviewRow()
+                {
+                    TrackNumber = track.TrackNumber,
+                    TrackName = track.TrackName
+                });
+            }
+            else
+            {
+                Model.Rows.AddRange(track.Songs.Select(x => new TrackOverviewViewModel.TrackOverviewRow()
+                {
+                    HasSong = true,
+                    SongInfo = x,
+                    TrackNumber = track.TrackNumber,
+                    TrackName = track.TrackName + (x.IsAlt ? " (Alt)" : ""),
+                    Name = x.SongName ?? "",
+                    Artist = x.Artist ?? "",
+                    Album = x.Album ?? "",
+                    File = !x.MsuPcmInfo.HasFiles() ? ""
+                        : x.MsuPcmInfo.GetFileCount() == 1
+                            ? x.MsuPcmInfo.File!
+                            : $"{x.MsuPcmInfo.GetFileCount()} files"
+                }));
+            }
+        }
+
+        var numTracks = tracks.Count;
+        var numCompletedTracks = tracks.Count(x => x.Songs.Any(y => y.HasFiles()));
+        Model.CompletedTrackDetails = $"{numCompletedTracks} out of {numTracks} tracks have songs with audio files";
+        
+        DataContext = Model;
+    }
+
+    public TrackOverviewViewModel Model { get; set; } = new();
+
+    public event EventHandler<TrackEventArgs>? OnSelectedTrack;
+
+    private void AudioDataGrid_OnDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (e.Source is not TextBlock && e.Source is not Border { Name: "CellBorder"})
+        {
+            return;
+        }
+
+        var selectedItems = this.Find<DataGrid>(nameof(TrackDataGrid))!.SelectedItems;
+        if (selectedItems.Count <= 0)
+        {
+            return;
+        }
+        
+        var row = selectedItems[0] as TrackOverviewViewModel.TrackOverviewRow;
+
+        if (row == null)
+        {
+            return;
+        }
+        OnSelectedTrack?.Invoke(this, new TrackEventArgs(row.TrackNumber));
+    }
+
+    private void IsCompleteCheckBox_OnIsCheckedChanged(object? sender, RoutedEventArgs e)
+    {
+        Task.Run(() =>
+        {
+            Task.Delay(TimeSpan.FromSeconds(0.2));
+            Dispatcher.UIThread.Invoke(() =>
+            {
+                GetFinishedSongText();
+            });
+        });
+
+    }
+
+    private void GetFinishedSongText()
+    {
+        var numSongs = Model.Rows.Count(x => x.HasSong);
+        var numFinishedSongs = Model.Rows.Count(x => x.HasSong && x.SongInfo?.IsComplete == true);
+        Model.CompletedSongDetails = $"{numFinishedSongs} out of {numSongs} songs are marked as finished";
+    }
+}

--- a/MSUScripter/MSUScripter.csproj
+++ b/MSUScripter/MSUScripter.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <ApplicationIcon>MSUScripterIcon.ico</ApplicationIcon>
         <PackageIcon>MSUScripterIcon.ico</PackageIcon>
-        <Version>2.0.1</Version>
+        <Version>2.1.0-rc.1</Version>
         <RuntimeFrameworkVersion>7.0.0</RuntimeFrameworkVersion>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     </PropertyGroup>

--- a/MSUScripter/Services/PyMusicLooperService.cs
+++ b/MSUScripter/Services/PyMusicLooperService.cs
@@ -177,7 +177,7 @@ public class PyMusicLooperService
         
         var successful = _python.RunCommand(arguments, out var result, out var error);
 
-        var regexValid = new Regex("^[0-9- .e\r\n]+$");
+        var regexValid = new Regex("^[0-9- .-nae\r\n]+$");
         if (!successful || !regexValid.IsMatch(result))
         {
             message = CleanPyMusicLooperError(string.IsNullOrEmpty(error) ? result : error);
@@ -187,9 +187,17 @@ public class PyMusicLooperService
         message = "";
 
         return result.Split("\n")
-            .Select(x => x.Split(" "))
-            .Select(x => (int.Parse(x[0], CultureInfo.InvariantCulture), int.Parse(x[1], CultureInfo.InvariantCulture), decimal.Parse(x[4], CultureInfo.InvariantCulture)))
+            .Select(ParsePyMusicLooperLine)
             .ToList();
+    }
+
+    private (int, int, decimal) ParsePyMusicLooperLine(string input)
+    {
+        var parts = input.Split(" ");
+        int.TryParse(parts[0], CultureInfo.InvariantCulture, out var loopStart);
+        int.TryParse(parts[1], CultureInfo.InvariantCulture, out var loopEnd);
+        decimal.TryParse(parts[4], CultureInfo.InvariantCulture, out var score);
+        return (loopStart, loopEnd, score);
     }
 
     private string GetArguments(string filePath, double minDurationMultiplier = 0.25, int? minLoopDuration = null, int? maxLoopDuration = null, int? approximateLoopStart = null, int? approximateLoopEnd = null)

--- a/MSUScripter/ViewModels/MsuSongInfoViewModel.cs
+++ b/MSUScripter/ViewModels/MsuSongInfoViewModel.cs
@@ -65,6 +65,13 @@ public class MsuSongInfoViewModel : INotifyPropertyChanged
         set => SetField(ref _isAlt, value);
     }
     
+    private bool _isComplete;
+    public bool IsComplete
+    {
+        get => _isComplete;
+        set => SetField(ref _isComplete, value);
+    }
+    
     private bool _checkCopyright = true;
     public bool CheckCopyright
     {

--- a/MSUScripter/ViewModels/MsuSongMsuPcmInfoViewModel.cs
+++ b/MSUScripter/ViewModels/MsuSongMsuPcmInfoViewModel.cs
@@ -209,6 +209,12 @@ public class MsuSongMsuPcmInfoViewModel : INotifyPropertyChanged
     {
         return !string.IsNullOrEmpty(File) || SubTracks.Any(x => x.HasFiles()) || SubChannels.Any(x => x.HasFiles());
     }
+    
+    public int GetFileCount()
+    {
+        var fileCount = !string.IsNullOrEmpty(File) ? 1 : 0;
+        return fileCount + SubTracks.Sum(x => x.GetFileCount()) + SubChannels.Sum(x => x.GetFileCount());
+    }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 

--- a/MSUScripter/ViewModels/PackageMsuViewModel.cs
+++ b/MSUScripter/ViewModels/PackageMsuViewModel.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace MSUScripter.ViewModels;
+
+public class PackageMsuViewModel : INotifyPropertyChanged
+{
+
+    private string _buttonText = "Cancel";
+    public string ButtonText
+    {
+        get => _buttonText;
+        set => SetField(ref _buttonText, value);
+    }
+
+    private MsuProjectViewModel _project = new();
+
+    public MsuProjectViewModel Project
+    {
+        get => _project;
+        set => SetField(ref _project, value);
+    }
+
+    private string _response = "";
+
+    public string Response
+    {
+        get => _response;
+        set => SetField(ref _response, value);
+    }
+    
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+}

--- a/MSUScripter/ViewModels/TrackOverviewViewModel.cs
+++ b/MSUScripter/ViewModels/TrackOverviewViewModel.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace MSUScripter.ViewModels;
+
+public class TrackOverviewViewModel : INotifyPropertyChanged
+{
+    public List<TrackOverviewRow> Rows { get; set; } = new();
+
+    private string _completedSongDetails = "";
+    public string CompletedSongDetails
+    {
+        
+        get => _completedSongDetails;
+        set => SetField(ref _completedSongDetails, value);
+    }
+
+    private string _completedTrackDetails = "";
+    public string CompletedTrackDetails
+    {
+        
+        get => _completedTrackDetails;
+        set => SetField(ref _completedTrackDetails, value);
+    }
+
+    public int SelectedIndex { get; set; } = 0;
+    
+    public class TrackOverviewRow
+    {
+        public bool HasSong { get; set; }
+        public MsuSongInfoViewModel? SongInfo { get; set; }
+        public required int TrackNumber { get; set; }
+        public required string TrackName { get; set; }
+        public string Name { get; set; } = "";
+        public string Artist { get; set; } = "";
+        public string Album { get; set; } = "";
+        public string File { get; set; } = "";
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+}


### PR DESCRIPTION
- Fixes #57: Project wide normalization ignored until restart
- Fixes #56: Add song window doesn't let you add songs when PyMusicLooper fails/is disabled
- Closes #55: Added drag & drop functionality
- Closes #52: Added MSU track overview
- Closes #51: Added bundle msu option
- Closes #50: Added warning that both approximate loop times are required
- Added method to mark songs as finished
- Fixed issue with not being able to parse PyMusicLooper with scientific notation or "NaN" records