### PR TITLE
Release 2.1.0

### DIFF
--- a/MSUScripter/Controls/AddSongWindow.axaml
+++ b/MSUScripter/Controls/AddSongWindow.axaml
@@ -7,6 +7,7 @@
         xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
         mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="600"
         Width="1000" Height="700"
+        MinWidth="1000" MinHeight="700"
         x:Class="MSUScripter.Controls.AddSongWindow"
         Title="Add Song"
         Loaded="Control_OnLoaded"
@@ -24,6 +25,11 @@
                         Name="AddSongButton"
                         Click="AddSongButton_OnClick"
                         Content="{Binding AddSongButtonText}" />
+                <Button Margin="5, 0" 
+                        IsEnabled="{Binding CanAddSong}"
+                        Name="AddSongAndCloseButton"
+                        Click="AddSongAndCloseButton_OnClick"
+                        Content="Add and Close" />
                 <Button Margin="5, 0" Name="CloseButton" Click="CloseButton_OnClick">
                     Close
                 </Button>

--- a/MSUScripter/Controls/AddSongWindow.axaml.cs
+++ b/MSUScripter/Controls/AddSongWindow.axaml.cs
@@ -329,6 +329,8 @@ public partial class AddSongWindow : Window
 
     private void Window_OnClosing(object? sender, WindowClosingEventArgs e)
     {
+        _ = StopSong();
+        
         if (_forceClosing)
         {
             return;

--- a/MSUScripter/Controls/AddSongWindow.axaml.cs
+++ b/MSUScripter/Controls/AddSongWindow.axaml.cs
@@ -242,10 +242,10 @@ public partial class AddSongWindow : Window
             return;
         }
 
-        _ = AddSong();
+        _ = AddSong(false);
     }
 
-    private async Task AddSong()
+    private async Task AddSong(bool closeAfter)
     {
         var successful = _msuPcmService.CreateTempPcm(_project, Model.FilePath, out var tempPcmPath, out var message,
             out var generated, Model.LoopPoint, Model.TrimEnd, Model.Normalization ?? ProjectModel.BasicInfo.Normalization, Model.TrimStart);
@@ -308,16 +308,23 @@ public partial class AddSongWindow : Window
 
         song.MsuPcmInfo.Song = song;
         track.AddSong(song);
-
+        
         _pyMusicLooperPanel.Model = new();
         Model.Clear();
 
-        Model.AddSongButtonText = "Added Song";
-        _ = Task.Run(() =>
+        if (closeAfter)
         {
-            Thread.Sleep(TimeSpan.FromSeconds(3));
-            Model.AddSongButtonText = "Add Song";
-        });
+            Close();
+        }
+        else
+        {
+            Model.AddSongButtonText = "Added Song";
+            _ = Task.Run(() =>
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(3));
+                Model.AddSongButtonText = "Add Song";
+            });
+        }
     }
 
     private void Window_OnClosing(object? sender, WindowClosingEventArgs e)
@@ -432,5 +439,15 @@ public partial class AddSongWindow : Window
         }
     }
 
-    
+
+    private void AddSongAndCloseButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (Model.SelectedIndex <= 0 || string.IsNullOrEmpty(Model.FilePath))
+        {
+            return;
+        }
+
+        _ = AddSong(true);
+
+    }
 }

--- a/MSUScripter/Controls/EditProjectPanel.axaml.cs
+++ b/MSUScripter/Controls/EditProjectPanel.axaml.cs
@@ -83,6 +83,18 @@ public partial class EditProjectPanel : UserControl
         _backupTimer.Start();
     }
 
+    public void DisplayMsuDetails()
+    {
+        this.Find<AutoCompleteBox>(nameof(TrackSearchAutoCompleteBox))!.Text = MsuDetailsTitle;
+        this.Find<ComboBox>(nameof(PageComboBox))!.SelectedIndex = 0;
+    }
+
+    public void DisplayTrackOverview()
+    {
+        this.Find<AutoCompleteBox>(nameof(TrackSearchAutoCompleteBox))!.Text = TrackOverviewTitle;
+        this.Find<ComboBox>(nameof(PageComboBox))!.SelectedIndex = 1;
+    }
+
     private void BackupTimerOnElapsed(object? sender, ElapsedEventArgs e)
     {
         if (_lastAutoSave == null)

--- a/MSUScripter/Controls/MainWindow.axaml
+++ b/MSUScripter/Controls/MainWindow.axaml
@@ -40,6 +40,22 @@
                     Padding="5"
                     Click="SettingsMenuItem_OnClick"
                 ></MenuItem>
+                <MenuItem 
+                    Header="_MSU Details" 
+                    Name="MsuDetailsMenuItem"
+                    FontSize="11"
+                    Padding="5"
+                    IsVisible="False"
+                    Click="MsuDetailsMenuItem_OnClick"
+                ></MenuItem>
+                <MenuItem 
+                    Header="_Track Overview" 
+                    Name="TrackOverviewMenuItem"
+                    FontSize="11"
+                    Padding="5"
+                    IsVisible="False"
+                    Click="TrackOverviewMenuItem_OnClick"
+                ></MenuItem>
             </Menu>
         </Border>
         

--- a/MSUScripter/Controls/MainWindow.axaml.cs
+++ b/MSUScripter/Controls/MainWindow.axaml.cs
@@ -76,6 +76,8 @@ public partial class MainWindow : Window
         _newProjectPanel = _services.GetRequiredService<NewProjectPanel>();
         MainPanel.Children.Add(_newProjectPanel);
         _newProjectPanel.OnProjectSelected += OnProjectSelected;
+        this.Find<MenuItem>(nameof(MsuDetailsMenuItem))!.IsVisible = false;
+        this.Find<MenuItem>(nameof(TrackOverviewMenuItem))!.IsVisible = false;
         UpdateTitle(null);
     }
     
@@ -100,6 +102,8 @@ public partial class MainWindow : Window
         _editProjectPanel = _services.GetRequiredService<EditProjectPanel>();
         _editProjectPanel.SetProject(project);
         MainPanel.Children.Add(_editProjectPanel);
+        this.Find<MenuItem>(nameof(MsuDetailsMenuItem))!.IsVisible = true;
+        this.Find<MenuItem>(nameof(TrackOverviewMenuItem))!.IsVisible = true;
         UpdateTitle(project);
     }
     
@@ -179,5 +183,15 @@ public partial class MainWindow : Window
 
         _msuPcmService?.DeleteTempPcms();
         _msuPcmService?.DeleteTempJsonFiles();
+    }
+
+    private void MsuDetailsMenuItem_OnClick(object? sender, RoutedEventArgs e)
+    {
+        _editProjectPanel?.DisplayMsuDetails();
+    }
+
+    private void TrackOverviewMenuItem_OnClick(object? sender, RoutedEventArgs e)
+    {
+        _editProjectPanel?.DisplayTrackOverview();
     }
 }

--- a/MSUScripter/Controls/MusicLooperWindow.axaml
+++ b/MSUScripter/Controls/MusicLooperWindow.axaml
@@ -7,6 +7,7 @@
         Height="380" Width="1000"
         CanResize="False"
         Loaded="Control_OnLoaded"
+        Closing="Window_OnClosing"
         Icon="/Assets/MSUScripterIcon.ico"
         x:Class="MSUScripter.Controls.MusicLooperWindow"
         Title="PyMusicLooper - MSU Scripter">

--- a/MSUScripter/Controls/MusicLooperWindow.axaml.cs
+++ b/MSUScripter/Controls/MusicLooperWindow.axaml.cs
@@ -2,6 +2,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using MSUScripter.Services;
 using MSUScripter.ViewModels;
 
 namespace MSUScripter.Controls;
@@ -10,15 +11,17 @@ public partial class MusicLooperWindow : Window
 {
     private readonly PyMusicLooperPanel? _pyMusicLooperPanel;
     private readonly AudioControl? _audioControl = null!;
+    private readonly IAudioPlayerService? _audioPlayerService;
     
-    public MusicLooperWindow() : this(null, null)
+    public MusicLooperWindow() : this(null, null, null)
     {
     }
     
-    public MusicLooperWindow(PyMusicLooperPanel? pyMusicLooperPanel, AudioControl? audioControl)
+    public MusicLooperWindow(PyMusicLooperPanel? pyMusicLooperPanel, AudioControl? audioControl, IAudioPlayerService? audioPlayerService)
     {
         _pyMusicLooperPanel = pyMusicLooperPanel;
-        _audioControl = audioControl; 
+        _audioControl = audioControl;
+        _audioPlayerService = audioPlayerService;
         InitializeComponent();
         WindowStartupLocation = WindowStartupLocation.CenterOwner;
     }
@@ -76,5 +79,10 @@ public partial class MusicLooperWindow : Window
         {
             AudioPanelParent.Children.Add(_audioControl);    
         }
+    }
+
+    private void Window_OnClosing(object? sender, WindowClosingEventArgs e)
+    {
+        _ = _audioPlayerService?.StopSongAsync();
     }
 }

--- a/MSUScripter/Controls/MusicLooperWindow.axaml.cs
+++ b/MSUScripter/Controls/MusicLooperWindow.axaml.cs
@@ -2,6 +2,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using MSUScripter.Services;
 using MSUScripter.ViewModels;
 
@@ -72,13 +73,16 @@ public partial class MusicLooperWindow : Window
     private void Control_OnLoaded(object? sender, RoutedEventArgs e)
     {
         if (_pyMusicLooperPanel == null) return;
-        this.Find<DockPanel>(nameof(DockPanel))!.Children.Add(_pyMusicLooperPanel);
-        _pyMusicLooperPanel.Margin = new Thickness(5);
-
-        if (_audioControl != null)
+        Dispatcher.UIThread.Invoke(() =>
         {
-            AudioPanelParent.Children.Add(_audioControl);    
-        }
+            this.Find<DockPanel>(nameof(DockPanel))!.Children.Add(_pyMusicLooperPanel);
+            _pyMusicLooperPanel.Margin = new Thickness(5);
+
+            if (_audioControl != null)
+            {
+                AudioPanelParent.Children.Add(_audioControl);
+            }
+        });
     }
 
     private void Window_OnClosing(object? sender, WindowClosingEventArgs e)


### PR DESCRIPTION
Fixes #62 (possibly): fixed a single instance of a crash when opening the PyMusicLooper window
Closes #63: stop playing when when closing the Add Song and PyMusicLooper windows
Closes #60: added menu buttons for going back to the MSU Details and Track Overview pages
Closes #59: added a "Add and Close" button to the Add Song window