### PR TITLE
Release 2.1.0

### DIFF
--- a/MSUScripter/Controls/AudioAnalysisWindow.axaml.cs
+++ b/MSUScripter/Controls/AudioAnalysisWindow.axaml.cs
@@ -45,11 +45,8 @@ public partial class AudioAnalysisWindow : Window
                 SongName = Path.GetRelativePath(msuDirectory, new FileInfo(x.OutputPath!).FullName),
                 TrackName = x.TrackName,
                 TrackNumber = x.TrackNumber,
-                Path = !string.IsNullOrEmpty(x.OutputPath) && File.Exists(x.OutputPath) ? x.OutputPath : "Missing",
-                HasWarning = string.IsNullOrEmpty(x.OutputPath) || !File.Exists(x.OutputPath),
-                WarningMessage = !string.IsNullOrEmpty(x.OutputPath) && File.Exists(x.OutputPath) ? "" : "PCM file missing. Export the MSU to generate all PCM files.",
+                Path = x.OutputPath ?? "",
                 OriginalViewModel = x,
-                HasFile = !string.IsNullOrEmpty(x.OutputPath) && File.Exists(x.OutputPath)
             })
             .ToList();
 

--- a/MSUScripter/Controls/AudioAnalysisWindow.axaml.cs
+++ b/MSUScripter/Controls/AudioAnalysisWindow.axaml.cs
@@ -39,15 +39,17 @@ public partial class AudioAnalysisWindow : Window
         if (string.IsNullOrEmpty(msuDirectory)) return;
 
         var songs = project.Tracks.SelectMany(x => x.Songs)
-            .Where(x => !string.IsNullOrEmpty(x.OutputPath) && File.Exists(x.OutputPath))
             .OrderBy(x => x.TrackNumber)
             .Select(x => new AudioAnalysisSongViewModel()
             {
                 SongName = Path.GetRelativePath(msuDirectory, new FileInfo(x.OutputPath!).FullName),
                 TrackName = x.TrackName,
                 TrackNumber = x.TrackNumber,
-                Path = x.OutputPath!,
-                OriginalViewModel = x
+                Path = !string.IsNullOrEmpty(x.OutputPath) && File.Exists(x.OutputPath) ? x.OutputPath : "Missing",
+                HasWarning = string.IsNullOrEmpty(x.OutputPath) || !File.Exists(x.OutputPath),
+                WarningMessage = !string.IsNullOrEmpty(x.OutputPath) && File.Exists(x.OutputPath) ? "" : "PCM file missing. Export the MSU to generate all PCM files.",
+                OriginalViewModel = x,
+                HasFile = !string.IsNullOrEmpty(x.OutputPath) && File.Exists(x.OutputPath)
             })
             .ToList();
 

--- a/MSUScripter/Controls/EditProjectPanel.axaml.cs
+++ b/MSUScripter/Controls/EditProjectPanel.axaml.cs
@@ -800,8 +800,27 @@ public partial class EditProjectPanel : UserControl
 
     private void ExportButton_Package_OnClick(object? sender, RoutedEventArgs e)
     {
+        _ = PackageProject();
+    }
+
+    private async Task PackageProject()
+    {
+        if (_projectViewModel == null)
+        {
+            return;
+        }
+
+        if (_projectViewModel.BasicInfo.IsMsuPcmProject && _projectViewModel.Tracks.SelectMany(x => x.Songs).Any(x => x.HasChangesSince(x.LastGeneratedDate)))
+        {
+            var result = await ShowYesNoWindow("One or more PCM file is out of date. It is recommended to export the MSU first before packaging. Do you want to continue?");
+            if (result != MessageWindowResult.Yes)
+            {
+                return;
+            }
+        }
+
         this.Find<ComboBox>(nameof(PageComboBox))!.Focus();
         var packageWindow = new PackageMsuWindow(_projectViewModel!);
-        packageWindow.ShowDialog(App.MainWindow!);
+        await packageWindow.ShowDialog(App.MainWindow!);
     }
 }

--- a/MSUScripter/Controls/MsuPcmGenerationWindow.axaml.cs
+++ b/MSUScripter/Controls/MsuPcmGenerationWindow.axaml.cs
@@ -100,6 +100,7 @@ public partial class MsuPcmGenerationWindow : Window
                     }
                     else
                     {
+                        songViewModel.LastGeneratedDate = DateTime.Now;
                         songDetails.Message = "Success!";
                     }
                     

--- a/MSUScripter/MSUScripter.csproj
+++ b/MSUScripter/MSUScripter.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <ApplicationIcon>MSUScripterIcon.ico</ApplicationIcon>
         <PackageIcon>MSUScripterIcon.ico</PackageIcon>
-        <Version>2.1.0-rc.1</Version>
+        <Version>2.1.0-rc.3</Version>
         <RuntimeFrameworkVersion>7.0.0</RuntimeFrameworkVersion>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     </PropertyGroup>

--- a/MSUScripter/Services/AudioAnalysisService.cs
+++ b/MSUScripter/Services/AudioAnalysisService.cs
@@ -30,8 +30,12 @@ public class AudioAnalysisService
     public void AnalyzePcmFiles(MsuProjectViewModel projectViewModel, AudioAnalysisViewModel audioAnalysis, CancellationToken ct = new())
     {
         var project = _converterService.ConvertProject(projectViewModel);
+
+        var rowsToProcess = audioAnalysis.Rows.Where(x => x.HasFile);
+
+        audioAnalysis.SongsCompleted = audioAnalysis.Rows.Count(x => !x.HasFile);
         
-        Parallel.ForEachAsync(audioAnalysis.Rows,
+        Parallel.ForEachAsync(rowsToProcess,
             new ParallelOptions { MaxDegreeOfParallelism = 10, CancellationToken = ct },
             async (song, token) =>
             {

--- a/MSUScripter/Services/AudioAnalysisService.cs
+++ b/MSUScripter/Services/AudioAnalysisService.cs
@@ -30,12 +30,8 @@ public class AudioAnalysisService
     public void AnalyzePcmFiles(MsuProjectViewModel projectViewModel, AudioAnalysisViewModel audioAnalysis, CancellationToken ct = new())
     {
         var project = _converterService.ConvertProject(projectViewModel);
-
-        var rowsToProcess = audioAnalysis.Rows.Where(x => x.HasFile);
-
-        audioAnalysis.SongsCompleted = audioAnalysis.Rows.Count(x => !x.HasFile);
         
-        Parallel.ForEachAsync(rowsToProcess,
+        Parallel.ForEachAsync(audioAnalysis.Rows,
             new ParallelOptions { MaxDegreeOfParallelism = 10, CancellationToken = ct },
             async (song, token) =>
             {
@@ -52,19 +48,42 @@ public class AudioAnalysisService
     
     public async Task AnalyzePcmFile(MsuProject project, AudioAnalysisSongViewModel song)
     {
-        // Regenerate the pcm file if it has updates that have been made to it
-        if (project.BasicInfo.IsMsuPcmProject && song.OriginalViewModel != null && song.OriginalViewModel.HasChangesSince(song.OriginalViewModel.LastGeneratedDate) && song.OriginalViewModel.HasFiles())
+        if (string.IsNullOrEmpty(song.Path))
         {
-            _logger.LogInformation("PCM file {File} out of date, regenerating", song.Path);
-            GeneratePcmFile(project, song.OriginalViewModel);
+            song.HasWarning = true;
+            song.WarningMessage = "No output path for the song";
+            return;
+        }
+        else if (!project.BasicInfo.IsMsuPcmProject && !File.Exists(song.Path))
+        {
+            song.HasWarning = true;
+            song.WarningMessage = "PCM file missing";
+            return;
+        }
+        else if (project.BasicInfo.IsMsuPcmProject && song.OriginalViewModel?.HasFiles() != true && !File.Exists(song.Path))
+        {
+            song.HasWarning = true;
+            song.WarningMessage = "No input files specified for PCM file";
+            return;
         }
         
+        // Regenerate the pcm file if it has updates that have been made to it
+        if (project.BasicInfo.IsMsuPcmProject && song.OriginalViewModel != null && song.OriginalViewModel.HasFiles() && (song.OriginalViewModel.HasChangesSince(song.OriginalViewModel.LastGeneratedDate) || !File.Exists(song.Path)))
+        {
+            _logger.LogInformation("PCM file {File} out of date, regenerating", song.Path);
+            if (!GeneratePcmFile(project, song.OriginalViewModel))
+            {
+                song.HasWarning = true;
+                song.WarningMessage = "Could not generate new PCM file";
+            }
+        }
+            
         var data = await AnalyzeAudio(song.Path);
         song.ApplyAudioAnalysis(data);
         _logger.LogInformation("Analysis for pcm file {File} complete", song.Path);
     }
     
-    private void GeneratePcmFile(MsuProject project, MsuSongInfoViewModel songModel)
+    private bool GeneratePcmFile(MsuProject project, MsuSongInfoViewModel songModel)
     {
         var song = new MsuSongInfo();
         _converterService.ConvertViewModel(songModel, song);
@@ -79,6 +98,8 @@ public class AudioAnalysisService
             songModel.LastGeneratedDate = DateTime.Now;
             _logger.LogInformation("PCM file {File} regenerated successfully", song.OutputPath);
         }
+
+        return generated;
     }
     
     public async Task<AnalysisDataOutput> AnalyzeAudio(string path)

--- a/MSUScripter/ViewModels/AudioAnalysisSongViewModel.cs
+++ b/MSUScripter/ViewModels/AudioAnalysisSongViewModel.cs
@@ -73,14 +73,6 @@ public class AudioAnalysisSongViewModel : INotifyPropertyChanged
         set => SetField(ref _hasWarning, value);
     }
     
-    private bool _hasFile;
-
-    public bool HasFile
-    {
-        get => _hasFile;
-        set => SetField(ref _hasFile, value);
-    }
-
     public string _warningMessage = "";
 
     public string WarningMessage

--- a/MSUScripter/ViewModels/AudioAnalysisSongViewModel.cs
+++ b/MSUScripter/ViewModels/AudioAnalysisSongViewModel.cs
@@ -72,6 +72,14 @@ public class AudioAnalysisSongViewModel : INotifyPropertyChanged
         get => _hasWarning;
         set => SetField(ref _hasWarning, value);
     }
+    
+    private bool _hasFile;
+
+    public bool HasFile
+    {
+        get => _hasFile;
+        set => SetField(ref _hasFile, value);
+    }
 
     public string _warningMessage = "";
 


### PR DESCRIPTION
Closes #65 - Copyright test now exports yaml file for files to handle MSUs with a lot of PCM files
Closes #67 - The audio analysis window will now generate missing PCMs and warn if it can't or it's missing in a non-msupcm++ project
Fixes #69 - Fixed Export MSU not updating PCM last generation time